### PR TITLE
e2e: Mount /var/lib/storageos in init container

### DIFF
--- a/pod.yaml
+++ b/pod.yaml
@@ -18,6 +18,9 @@ spec:
       - name: sys
         mountPath: /sys
         mountPropagation: Bidirectional
+      - name: state
+        mountPath: /var/lib/storageos
+        mountPropagation: Bidirectional
     securityContext:
       privileged: true
       capabilities:
@@ -34,3 +37,6 @@ spec:
     - name: sys
       hostPath:
         path: /sys
+    - name: state
+      hostPath:
+        path: /var/lib/storageos


### PR DESCRIPTION
Access to /var/lib/storageos is required by the upgrade script.