### PR TITLE
Upgrade DBupgrade tool

### DIFF
--- a/scripts/10-dbupgrade-v1v2/storageos_dbupgrade_v1v2
+++ b/scripts/10-dbupgrade-v1v2/storageos_dbupgrade_v1v2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9a84ca581fec54ae2964ca934fe1e433cc5eaadaafba7807ca76056e8841d85
-size 78496760
+oid sha256:1bb43ff45bd59f66f906dce72e2826717b93acb203482b4da0cbe7a3ee0a9ec9
+size 78516672


### PR DESCRIPTION
Upgrade the DB upgrade tool to the latest version. This includes a bugfix for the issue whereby failing to set the NODE_IMAGE to a valid version resulted in the executable still returning a zero (i.e. successful) error code. Now, setting an invalid NODE_IMAGE, or not setting NODE_IMAGE, results in the binary returning 1 (i.e. failure).