### PR TITLE
Add metadata for RH certification, bump to 1.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,28 @@
-FROM golang:1.12.9 AS build
+FROM golang:1.13.5 AS build
+
 WORKDIR /go/src/github.com/storageos/init/
 COPY . /go/src/github.com/storageos/init/
 RUN make build
 
 FROM registry.access.redhat.com/ubi8/ubi
+LABEL name="StorageOS Init" \
+    maintainer="support@storageos.com" \
+    vendor="StorageOS" \
+    version="1.0.1" \
+    release="1" \
+    distribution-scope="public" \
+    architecture="x86_64" \
+    url="https://docs.storageos.com" \
+    io.k8s.description="The StorageOS Init container prepares a node for running StorageOS." \
+    io.k8s.display-name="StorageOS Init" \
+    io.openshift.tags="storageos,storage,operator,pv,pvc,storageclass,persistent,csi" \
+    summary="Highly-available persistent block storage for containerized applications." \
+    description="StorageOS transforms commodity server or cloud based disk capacity into enterprise-class storage to run persistent workloads such as databases in containers. Provides high availability, low latency persistent block storage. No other hardware or software is required."
+
 RUN yum -y update && \
     yum -y install --disableplugin=subscription-manager kmod
+
 COPY scripts/ /scripts
+COPY --from=build /go/src/github.com/storageos/init/LICENSE /licenses/
 COPY --from=build /go/src/github.com/storageos/init/build/_output/bin/init /init
 CMD /init -scripts=/scripts

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,8 @@ run:
 # Generate mocks.
 generate:
 	go generate ./...
+
+# Prepare the repo for a new release. Run:
+#   NEW_VERSION=<version> make release
+release:
+	sed -i -e "s/version=.*/version=\"$(NEW_VERSION)\" \\\/g" Dockerfile

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Init container to prepare the environment for StorageOS.
 
-
 ## Options
 
 * `-scripts` - absolute path of the scripts directory.
@@ -12,20 +11,25 @@ Init container to prepare the environment for StorageOS.
 * `-dsName` - StorageOS k8s DaemonSet name. Use when running within a k8s cluster.
 * `-dsNamespace` - StorageOS k8s DaemonSet namespace. Use when running within a k8s cluster.
 
-
 ## Environment Variables
 
 * `NODE_IMAGE` - StorageOS Node container image.
 * `DAEMONSET_NAME` - StorageOS DaemonSet name.
 * `DAEMONSET_NAMESPACE` - StorageOS DaemonSet namespace.
 
-
 ## Build
 
-```
-$ make image IMAGE=storageos/init:test
+```console
+make image IMAGE=storageos/init:test
 ```
 
+## Release
+
+The version must be set in the `Dockerfile`.  To set it, run:
+
+```console
+NEW_VERSION=<version> make release
+```
 
 ## Run it on host
 
@@ -34,10 +38,9 @@ Build the init container with `make image` and run it on the host with
 
 Pass a StorageOS Node image and scripts directory as:
 
+```console
+make run SCRIPTS_PATH=scripts/ NODE_IMAGE=storageos/node:1.4.0
 ```
-$ make run SCRIPTS_PATH=scripts/ NODE_IMAGE=storageos/node:1.4.0
-```
-
 
 ## Script Framework
 
@@ -54,7 +57,8 @@ The scripts must start with shebang (`#!/bin/bash` for bash scripts) and must
 have executable permission(`chmod +x`).
 
 Example scripts dir:
-```
+
+```console
 scripts
 ├── 01-script.sh
 ├── 05-foo
@@ -67,7 +71,8 @@ scripts
 ```
 
 In the above example, the script execution order will be
-```
+
+```console
 01-script.sh, scriptx.sh, 07-scriptz.sh, scripty.sh
 ```
 


### PR DESCRIPTION
Adds metadata needed for Red hat certification.  Once merged, will configure in Red hat build service.

Also bumps go version to 1.13.5 to match Operator.

Fixes some lint warnings on the README.
