### PR TITLE
Make target_core_user and uio mandatory

### DIFF
--- a/scripts/01-lio/enable-lio.sh
+++ b/scripts/01-lio/enable-lio.sh
@@ -10,7 +10,7 @@ function module_error_log() {
     echo -e "${RE}ERROR: The kernel module $mod couldn't load properly. Please try to run${NC} modprobe $mod ${RE}. Once loaded, the directory $mod_dir should be accessible. Otherwise the module has not been loaded as expected.${NC}"
 }
 
-# Configfs can be built in the kernel, hence the module 
+# Configfs can be built in the kernel, hence the module
 # initstate file will not exist. Even though, the mount
 # is present and working
 echo "Checking configfs"
@@ -40,21 +40,17 @@ loop_dir="$target_dir"/loopback
 
 # Enable a mod if not present
 # /sys/module/$modname/initstate has got the word "live"
-# in case the kernel module is loaded and running 
-for mod in target_core_mod tcm_loop target_core_file uio target_core_user; do
+# in case the kernel module is loaded and running
+for mod in target_core_mod tcm_loop uio target_core_user; do
     state_file=/sys/module/$mod/initstate
     if [ -f "$state_file" ] && grep -q live "$state_file"; then
         echo "Module $mod is running"
-    else 
+    else
         echo "Module $mod is not running"
         echo "--> executing \"modprobe -b $mod\""
         if ! modprobe -b $mod; then
-            # core_user and uio are not mandatory
-            if [ "$mod" != "target_core_user" ] && [ "$mod" != "uio" ]; then
-                exit 1
-            else 
-                echo "Couldn't enable $mod"
-            fi
+            echo "Couldn't enable kernel module $mod"
+            exit 1
         fi
         # Enable module at boot
         mkdir -p /etc/modules-load.d
@@ -66,7 +62,7 @@ done
 # directories available on top of configfs
 
 [ ! -d "$target_dir" ] && echo "$target_dir doesn't exist" && module_error_log "target_core_mod" "$target_dir"
-[ ! -d "$core_dir" ]   && echo "$core_dir doesn't exist"   && module_error_log "target_core_file" "$core_dir"
+[ ! -d "$core_dir" ]   && echo "$core_dir doesn't exist"   && module_error_log "target_core_user" "$core_dir"
 [ ! -d "$loop_dir" ]   && echo "$loop_dir doesn't exist. Creating dir manually..." && mkdir $loop_dir
 
 echo "LIO set up is ready!"


### PR DESCRIPTION
We're removing FUSE support as of v2.7.0. This means the LIO start up script should not check for `target_core_file`. It should also mandate the `uio` and `target_core_user` and present and loadable, or the dataplane will not start.

We need to ensure that the older versions of StorageOS (v2.6.0 and below) don't attempt to use the init container with these changes. I'm not sure how we normally do this. Presumably, we release the init container in lock-step with the node container?